### PR TITLE
Fix discord server name.

### DIFF
--- a/denizen_scripts/HeroCraftSMP/no_creative.dsc
+++ b/denizen_scripts/HeroCraftSMP/no_creative.dsc
@@ -10,4 +10,4 @@ herocraft_command_monitoring:
   debug: false
   events:
     on command permission:adriftus.admin:
-      - bungeerun relay discord_sendMessage "def:A Staff|manager-logs|`<bungee.server>`<&co>`<player.name>` ran command `<context.command> <context.raw_args>`"
+      - bungeerun relay discord_sendMessage "def:Adriftus Staff|manager-logs|`<bungee.server>`<&co>`<player.name>` ran command `<context.command> <context.raw_args>`"

--- a/denizen_scripts/global/server/Adriftus Moderator Panel/functions/mod_message_discord.dsc
+++ b/denizen_scripts/global/server/Adriftus Moderator Panel/functions/mod_message_discord.dsc
@@ -13,5 +13,5 @@ mod_message_discord:
     - define fields:->:Moderator<&co><&sp><[moderator]>
     - define fields:->:Server<&co><&sp><bungee.server>
     - define message SEARCHABLE_<[uuid]><&nl>```<[fields].separated_by[<&nl>]>```
-    - bungeerun relay discord_sendMessage "def:A Staff|action-log|<[message].escaped>"
+    - bungeerun relay discord_sendMessage "def:Adriftus Staff|action-log|<[message].escaped>"
 

--- a/denizen_scripts/global/server/handlers/premium_economy.dsc
+++ b/denizen_scripts/global/server/handlers/premium_economy.dsc
@@ -91,7 +91,7 @@ premium_currency_give:
         - define map <map[economy.premium.current=<[newBal]>;economy.premium.lifetime=<[newLifetime]>]>
         - run global_player_data_modify_multiple def:<[player].uuid>|<[map]>
         - define message "SEARCHABLE_<[player].uuid>```<[player].name> has been given <[amount]> Premium Currency<&nl>Reason<&co> <[reason]>```"
-        - bungeerun relay discord_sendMessage "def:A Staff|manager-logs|<[message].escaped>"
+        - bungeerun relay discord_sendMessage "def:Adriftus Staff|manager-logs|<[message].escaped>"
 
 ## External ##
 # % ██ [ Remove player curency ] ██
@@ -110,7 +110,7 @@ premium_currency_remove:
           - determine false
         - run global_player_data_modify def:<[player].uuid>|economy.premium.current|<[amount]>
         - define message "SEARCHABLE_<[player].uuid>```<[player].name> has spent <[amount]> Premium Currency<&nl>Reason<&co> <[reason]>```"
-        - bungeerun relay discord_sendMessage "def:A Staff|manager-logs|<[message].escaped>"
+        - bungeerun relay discord_sendMessage "def:Adriftus Staff|manager-logs|<[message].escaped>"
         - determine true
 
 ## External ##
@@ -127,7 +127,7 @@ premium_currency_set:
           - determine false
         - run global_player_data_modify def:<[player].uuid>|economy.premium.current|<[amount]>
         - define message "SEARCHABLE_<[player].uuid>```<[player].name> was set to <[amount]> Premium Currency<&nl>Reason<&co> <[reason]>```"
-        - bungeerun relay discord_sendMessage "def:A Staff|manager-logs|<[message].escaped>"
+        - bungeerun relay discord_sendMessage "def:Adriftus Staff|manager-logs|<[message].escaped>"
         - determine true
 
 premium_currency_can_afford:

--- a/denizen_scripts/hub/repo_link/Berufeng/Banner_Designer.dsc
+++ b/denizen_scripts/hub/repo_link/Berufeng/Banner_Designer.dsc
@@ -978,4 +978,4 @@ Banner_Designer_Storage:
   type: task
   debug: false
   script:
-    - bungeerun relay discord_sendMessage "def:A Staff|custom-banners|custom_banner_RENAME:<&nl>    type: item<&nl>    debug: false<&nl>    material: <[converter_result].as_item.material.name><&nl>    display name:<&nl>    mechanisms:<&nl>        patterns:<&nl>          - <[converter_result].as_item.patterns.separated_by[<&nl>          - ]><&nl>    lore:<&nl>    -"
+    - bungeerun relay discord_sendMessage "def:Adriftus Staff|custom-banners|custom_banner_RENAME:<&nl>    type: item<&nl>    debug: false<&nl>    material: <[converter_result].as_item.material.name><&nl>    display name:<&nl>    mechanisms:<&nl>        patterns:<&nl>          - <[converter_result].as_item.patterns.separated_by[<&nl>          - ]><&nl>    lore:<&nl>    -"

--- a/denizen_scripts/hub/repo_link/no_creative.dsc
+++ b/denizen_scripts/hub/repo_link/no_creative.dsc
@@ -14,4 +14,4 @@ herocraft_command_monitoring:
   events:
     on command permission:adriftus.admin:
       - if !<script.data_key[data.ignored.<context.command>].exists>:
-        - bungeerun relay discord_sendMessage "def:A Staff|manager-logs|`<bungee.server>`<&co>`<player.name>` ran command `<context.command> <context.raw_args>`"
+        - bungeerun relay discord_sendMessage "def:Adriftus Staff|manager-logs|`<bungee.server>`<&co>`<player.name>` ran command `<context.command> <context.raw_args>`"

--- a/denizen_scripts/zanzabar/repo_link/no_creative.dsc
+++ b/denizen_scripts/zanzabar/repo_link/no_creative.dsc
@@ -10,4 +10,4 @@ herocraft_command_monitoring:
   debug: false
   events:
     on command permission:adriftus.admin:
-      - bungeerun relay discord_sendMessage "def:A Staff|manager-logs|`<bungee.server>`<&co>`<player.name>` ran command `<context.command> <context.raw_args>`"
+      - bungeerun relay discord_sendMessage "def:Adriftus Staff|manager-logs|`<bungee.server>`<&co>`<player.name>` ran command `<context.command> <context.raw_args>`"


### PR DESCRIPTION
We should maybe define the public and staff discord server IDs in a map. Then, use the key names in the `discord_sendMessage` task.