### PR TITLE
Starter Kit for Herocraft

### DIFF
--- a/denizen_scripts/HeroCraft/first_join.dsc
+++ b/denizen_scripts/HeroCraft/first_join.dsc
@@ -17,3 +17,6 @@ first_join:
           - wait 5s
           - while stop if:<player.is_online.not>
         - take item:elytra
+        - equip head:leather_helmet chest:leather_chestplate legs:leather_leggings feet:leather_boots
+        - foreach stone_sword|stone_pickaxe|stone_axe|stone_shovel|tpa_crystal|campfire|food_crate as:item:
+          - give <[item]>


### PR DESCRIPTION
This addition gives players a "starter kit" on Herocraft which consists of:

- Leather Armor
- Stone Tools (excluding hoe)
- TPA Crystal
- Campfire
- Food Crate