### PR TITLE
Steel block and grapple fix

### DIFF
--- a/denizen_scripts/HeroCraft/items/tools/grappling_hook.dsc
+++ b/denizen_scripts/HeroCraft/items/tools/grappling_hook.dsc
@@ -49,7 +49,7 @@ grappling_hook_better:
       output_quantity: 1
       input:
       - steel_block|steel_block|air
-      - steel_block|grappling_hook_basic|string
+      - steel_block|bow|string
       - air|string|stick
 
 

--- a/denizen_scripts/HeroCraft/items/tools/steel_tools/steel_materials.dsc
+++ b/denizen_scripts/HeroCraft/items/tools/steel_tools/steel_materials.dsc
@@ -29,6 +29,10 @@ steel_ingot:
       cook_time: 550s
       experience: 0.15
       input: iron_ingot
+    5:
+      type: shapeless
+      input: steel_block
+      output_quantity: 9
 
 
 raw_steel:


### PR DESCRIPTION
Steel blocks to be converted to ingots
Grapple uses bow like Basic grapple, instead of a basic grapple - Cheaper but gets around the recipe being broken due to grapple UUIDs